### PR TITLE
Reversed name structure of remaining account in 2012-06

### DIFF
--- a/FY2013/2012-06.beancount
+++ b/FY2013/2012-06.beancount
@@ -5,14 +5,14 @@
               ; Assets:New-Alliance:Operations is already open, in FY2013.beancount
 
 ; Samurai was our first payment processor.
-2012-06-01 open Assets:Escrow:Samurai USD
-2012-06-01 open Assets:Operations:Samurai USD
-2012-06-01 open Income:Fees:Samurai USD
-2012-06-01 open Expenses:Fees:Samurai USD
+2012-06-01 open Assets:Samurai:Escrow USD
+2012-06-01 open Assets:Samurai:Operations USD
+2012-06-01 open Income:Samurai:Fees USD
+2012-06-01 open Expenses:Samurai:Fees USD
 
 ; Unfortunately, they proved unreliable.
-2012-06-01 open Income:Errors:Samurai USD
-2012-06-01 open Expenses:Errors:Samurai USD
+2012-06-01 open Income:Samurai:Errors USD
+2012-06-01 open Expenses:Samurai:Errors USD
 
 ; This is the big one. We are holding your money!
 2012-06-01 open Liabilities:Escrow USD
@@ -22,25 +22,25 @@
 ; ===============
 
 2012-06-01 * "We charged participants via Samurai."
-    Assets:Escrow:Samurai             2.96 USD
-    Assets:Operations:Samurai         0.34 USD
-    Income:Fees:Samurai              -0.34 USD
+    Assets:Samurai:Escrow             2.96 USD
+    Assets:Samurai:Operations         0.34 USD
+    Income:Samurai:Fees              -0.34 USD
     Liabilities:Escrow               -2.96 USD
 
 2012-06-04 * "Samurai settled with us. We expected 3.30, but saw 7.56: an overpayment of 4.26."
     Assets:New-Alliance:Escrow        2.96 USD
     Assets:New-Alliance:Operations    0.34 USD
     Assets:New-Alliance:Operations    4.26 USD
-    Income:Errors:Samurai            -4.26 USD
-    Assets:Operations:Samurai        -0.34 USD
-    Assets:Escrow:Samurai            -2.96 USD
+    Income:Samurai:Errors            -4.26 USD
+    Assets:Samurai:Operations        -0.34 USD
+    Assets:Samurai:Escrow            -2.96 USD
 
 2012-06-04 * "Samurai withdrew funds."
-    Expenses:Fees:Samurai             0.08 USD
+    Expenses:Samurai:Fees             0.08 USD
     Assets:New-Alliance:Operations   -0.08 USD
 
 2012-06-04 * "Samurai withdrew more funds for some reason."
-    Expenses:Fees:Samurai            31.35 USD
+    Expenses:Samurai:Fees            31.35 USD
     Assets:New-Alliance:Operations  -31.35 USD
 
 
@@ -48,27 +48,27 @@
 ; ===============
 
 2012-06-08 * "We charged participants via Samurai."
-    Assets:Escrow:Samurai            23.17 USD
-    Assets:Operations:Samurai         2.11 USD
-    Income:Fees:Samurai              -2.11 USD
+    Assets:Samurai:Escrow            23.17 USD
+    Assets:Samurai:Operations         2.11 USD
+    Income:Samurai:Fees              -2.11 USD
     Liabilities:Escrow              -23.17 USD
 
 2012-06-11 * "Samurai settled AMEX charges with us. We expected 0.61, and we saw 0.61."
     Assets:New-Alliance:Escrow        0.48 USD
     Assets:New-Alliance:Operations    0.13 USD
-    Assets:Operations:Samurai        -0.13 USD
-    Assets:Escrow:Samurai            -0.48 USD
+    Assets:Samurai:Operations        -0.13 USD
+    Assets:Samurai:Escrow            -0.48 USD
 
 2012-06-11 * "Samurai settled VISA/MC. We expected 24.67, but saw 24.11: an underpayment of 0.56."
     Assets:New-Alliance:Escrow       22.69 USD
     Assets:New-Alliance:Operations    1.98 USD
-    Expenses:Errors:Samurai           0.56 USD
+    Expenses:Samurai:Errors           0.56 USD
     Assets:New-Alliance:Operations   -0.56 USD
-    Assets:Operations:Samurai        -1.98 USD
-    Assets:Escrow:Samurai           -22.69 USD
+    Assets:Samurai:Operations        -1.98 USD
+    Assets:Samurai:Escrow           -22.69 USD
 
 2012-06-11 * "Samurai withdrew funds."
-    Expenses:Fees:Samurai             2.00 USD
+    Expenses:Samurai:Fees             2.00 USD
     Assets:New-Alliance:Operations   -2.00 USD
 
 
@@ -76,9 +76,9 @@
 ; ===============
 
 2012-06-15 * "We charged participants via Samurai."
-    Assets:Escrow:Samurai             1.36 USD
-    Assets:Operations:Samurai         0.69 USD
-    Income:Fees:Samurai              -0.69 USD
+    Assets:Samurai:Escrow             1.36 USD
+    Assets:Samurai:Operations         0.69 USD
+    Income:Samurai:Fees              -0.69 USD
     Liabilities:Escrow               -1.36 USD
 
 ; Our first payout!
@@ -100,65 +100,65 @@
 2012-06-18 * "Samurai settled with us. We expected 2.05, but saw 2.01: an underpayment of 0.04."
     Assets:New-Alliance:Escrow        1.36 USD
     Assets:New-Alliance:Operations    0.69 USD
-    Expenses:Errors:Samurai           0.04 USD
+    Expenses:Samurai:Errors           0.04 USD
     Assets:New-Alliance:Operations   -0.04 USD
-    Assets:Operations:Samurai        -0.69 USD
-    Assets:Escrow:Samurai            -1.36 USD
+    Assets:Samurai:Operations        -0.69 USD
+    Assets:Samurai:Escrow            -1.36 USD
 
 
 ; Testing out Stripe
 ; ==================
 
-2012-06-15 open Assets:Operations:Stripe USD
+2012-06-15 open Assets:Stripe:Operations USD
 2012-06-15 open Income:Testing USD
-2012-06-15 open Expenses:Fees:Stripe USD
+2012-06-15 open Expenses:Stripe:Fees USD
 
 2012-06-15 * "We charged Chad via Stripe."
-    Assets:Operations:Stripe          0.54 USD
+    Assets:Stripe:Operations          0.54 USD
     Income:Testing                   -0.54 USD
 
 2012-06-22 * "Stripe withheld their fee."
-    Expenses:Fees:Stripe              0.32 USD
-    Assets:Operations:Stripe         -0.32 USD
+    Expenses:Stripe:Fees              0.32 USD
+    Assets:Stripe:Operations         -0.32 USD
 
 2012-06-22 * "Stripe settled the net to us."
     Assets:New-Alliance:Operations    0.22 USD
-    Assets:Operations:Stripe         -0.22 USD
+    Assets:Stripe:Operations         -0.22 USD
 
 
 ; Stripe works!
 ; =============
 ; Let's set it up to use for payday.
 
-2012-06-22 open Assets:Escrow:Stripe USD
-2012-06-22 open Income:Fees:Stripe USD
+2012-06-22 open Assets:Stripe:Escrow USD
+2012-06-22 open Income:Stripe:Fees USD
 
 
 ; Gittip Payday 3
 ; ===============
 
 2012-06-22 * "We charged participants via Stripe."
-    Assets:Escrow:Stripe             20.67 USD
-    Assets:Operations:Stripe          4.62 USD
-    Income:Fees:Stripe               -4.62 USD
+    Assets:Stripe:Escrow             20.67 USD
+    Assets:Stripe:Operations          4.62 USD
+    Income:Stripe:Fees               -4.62 USD
     Liabilities:Escrow              -20.67 USD
 
 2012-06-28 * "Stripe settled the net to us."
     Assets:New-Alliance:Escrow       20.67 USD
     Assets:New-Alliance:Operations    0.30 USD
-    Expenses:Fees:Stripe              4.32 USD
-    Assets:Operations:Stripe         -4.32 USD
-    Assets:Operations:Stripe         -0.30 USD
-    Assets:Escrow:Stripe            -20.67 USD
+    Expenses:Stripe:Fees              4.32 USD
+    Assets:Stripe:Operations         -4.32 USD
+    Assets:Stripe:Operations         -0.30 USD
+    Assets:Stripe:Escrow            -20.67 USD
 
 
 ; Gittip Payday 4
 ; ===============
 
 2012-06-29 * "We charged participants via Stripe."
-    Assets:Escrow:Stripe             95.24 USD
-    Assets:Operations:Stripe         15.76 USD
-    Income:Fees:Stripe              -15.76 USD
+    Assets:Stripe:Escrow             95.24 USD
+    Assets:Stripe:Operations         15.76 USD
+    Income:Stripe:Fees              -15.76 USD
     Liabilities:Escrow              -95.24 USD
 
 
@@ -171,20 +171,20 @@
 2012-06-18 open Income:IHasAMoney USD
 
 2012-06-18 * "We charged a user via Samurai."
-    Assets:Operations:Samurai         2.92 USD
+    Assets:Samurai:Operations         2.92 USD
     Income:IHasAMoney                -2.92 USD
 
 2012-06-18 * "Samurai settled with us."
     Assets:New-Alliance:Operations    2.92 USD
-    Assets:Operations:Samurai        -2.92 USD
+    Assets:Samurai:Operations        -2.92 USD
 
 2012-06-25 * "We charged a user via Samurai."
-    Assets:Operations:Samurai         2.99 USD
+    Assets:Samurai:Operations         2.99 USD
     Income:IHasAMoney                -2.99 USD
 
 2012-06-25 * "Samurai settled with us."
     Assets:New-Alliance:Operations    2.99 USD
-    Assets:Operations:Samurai        -2.99 USD
+    Assets:Samurai:Operations        -2.99 USD
 
 
 ; Assert Balances


### PR DESCRIPTION
It appears after @whit537 made the changes in order to add the assert line at the end of the 2012-06.beancount he did not apply the change to all the account name. For example the 
`Assets:Operations:Samurai` did not change to `Assets:Samurai:Operations`. Thus this PR is to correct this issue.  @whit537 could you just verify if this is the structure of the account name that you want and merge when ever